### PR TITLE
Refactor CRUD models to keep code DRY. Fix bug in CRUD list. Update CRUD tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,4 @@
 log
 node_modules
 local.json
-*.swp
-*.swo
-*.swn
+*.sw[pon]

--- a/lib/components.js
+++ b/lib/components.js
@@ -3,74 +3,28 @@ const ALLOWED_FIELDS = {
         action: undefined
       };
 
-var crud = require('./crud');
+var scaffold = require('./scaffold');
 
-/* Component List Per Screen
- * Requires: web request, db connection
- * Returns: A listing of the user's components within a screen
+/* Get Component Prefix
+ * Requires: web request
+ * Returns: database prefix for components
  */
-exports.list = function(req, db, callback) {
-  crud.list(req, 'project:' + req.body.project_id + ':screen:' + req.params.id + ':component:*',
-    ALLOWED_FIELDS, db, function(err, componentList) {
-    
-    if (err) {
-      return callback(err);
-    }
+function getComponentPrefix(req) {
+  return 'project:' + req.body.project_id + ':screen:' + req.params.id
+    + ':component';
+}
 
-    return callback(null, componentList);
-  });
-};
-
-/* Component Add
- * Requires: web request, db connection
- * Returns: Component object if successful, false if email doesn't match, error if unsuccessful
+/* Get Default Component
+ * Requires: web request
+ * Returns: default component data
  */
-exports.add = function(req, db, callback) {
-  var defaultValues = {
+function getDefaultComponent(req) {
+  return {
     type: req.body.type,
     layout: req.body.layout,
     action: req.body.action
   };
+}
 
-  crud.add(req, 'project:' + req.body.project_id + ':screen:' + req.params.id + ':component',
-    defaultValues, db, function(err, component) {
-
-    if (err || !component) {
-      return callback(err);
-    }
-
-    return callback(null, component);
-  });
-};
-
-/* Component Update
- * Requires: web request, db connection, identifier
- * Returns: Component object if successful, false if email doesn't match, error if unsuccessful
- */
-exports.update = function(req, db, identifier, callback) {
-  crud.update(req, 'project:' + req.body.project_id + ':screen:' + req.params.id + ':component:' + identifier,
-    ALLOWED_FIELDS, db, function(err, component) {
-
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, component);
-  });
-};
-
-/* Component Delete
- * Requires: web request, db connection
- * Returns: True if deleted, error if unsuccessful
- */
-exports.remove = function(req, db, identifier, callback) {
-  crud.remove(req, 'project:' + req.body.project_id + ':screen:' + req.params.id + ':component:' + identifier,
-    db, function(err, status) {
-
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, status);
-  });
-};
+exports = module.exports = scaffold.generate(getComponentPrefix,
+    getDefaultComponent, ALLOWED_FIELDS);

--- a/lib/components.js
+++ b/lib/components.js
@@ -10,8 +10,8 @@ var scaffold = require('./scaffold');
  * Returns: database prefix for components
  */
 function getComponentPrefix(req) {
-  return 'project:' + req.body.project_id + ':screen:' + req.params.id
-    + ':component';
+  return 'project:' + req.body.project_id + ':screen:' + req.params.id +
+    ':component';
 }
 
 /* Get Default Component

--- a/lib/crud.js
+++ b/lib/crud.js
@@ -34,7 +34,7 @@ exports.list = function(keyName, allowedFields, db, callback) {
 };
 
 /* Gets an object
- * Requires: key name, db connection
+ * Requires: key name, db connection, callback
  * Calls: callback(error, object):
  *  error - null if object was retrieved or an error otherwise
  *  object - if error is null, the object
@@ -51,7 +51,7 @@ exports.get = function(keyName, db, callback) {
 };
 
 /* Adds an object
- * Requires: web request, key name, db connection
+ * Requires: web request, key name, db connection, callback
  * Calls: callback(error, object):
  *  error - null if the object was added or an error otherwise
  *  object - if error is null, the object that was added
@@ -90,7 +90,7 @@ exports.add = function(req, keyName, defaultValues, db, callback) {
 };
 
 /* Updates an object
- * Requires: web request, key name, allowed fields, db connection
+ * Requires: web request, key name, allowed fields, db connection, callback
  * Calls: callback(error, object):
  *  error - null if object was updated or error otherwise
  *  object - if error is null, the object that was updated
@@ -116,7 +116,7 @@ exports.update = function(req, keyName, allowedFields, db, callback) {
 };
 
 /* Removes an object
- * Requires: key name, db connection
+ * Requires: key name, db connection, callback
  * Calls: callback(error):
  *  error - null if the object was removed or an error otherwise
  */

--- a/lib/crud.js
+++ b/lib/crud.js
@@ -2,9 +2,9 @@
 
 var utils = require('./utils');
 
-/* Returns a list of the requested object
+/* Object list
  * Requires: key name, allowed fields, db connection, callback
- * Returns: callback(error, objectList):
+ * Calls: callback(error, objectList):
  *  error - null if object list was retrieved or an error otherwise
  *  objectList - if error is null, the list of objects
  */
@@ -13,105 +13,116 @@ exports.list = function(keyName, allowedFields, db, callback) {
 
   db.keys(keyName, function(err, objects) {
     if (err) {
-      return callback(err);
+      callback(err);
     }
+    else if (objects.length === 0) {
+      callback(null, objectList);
+    }
+    else {
+      objects.forEach(function(objectItem, counter) {
+        db.get(objectItem, function(errObject, objectItem) {
+          objectItem = JSON.parse(objectItem);
+          objectList.unshift(objectItem);
 
-    objects.forEach(function(objectItem, counter) {
-      db.get(objectItem, function(errObject, objectItem) {
-        objectItem = JSON.parse(objectItem);
-        objectList.unshift(objectItem);
-
-        if (counter === objects.length - 1) {
-          return callback(null, objectList);
-        }
+          if (counter === objects.length - 1) {
+            callback(null, objectList);
+          }
+        });
       });
-    });
+    }
   });
 };
 
 /* Gets an object
  * Requires: key name, db connection
- * Returns: callback(error, object):
+ * Calls: callback(error, object):
  *  error - null if object was retrieved or an error otherwise
  *  object - if error is null, the object
  */
 exports.get = function(keyName, db, callback) {
   db.get(keyName, function(err, objectItem) {
     if (err || !objectItem) {
-      return callback(err);
+      callback(err);
     }
-
-    return callback(null, JSON.parse(objectItem));
+    else {
+      callback(null, JSON.parse(objectItem));
+    }
   });
 };
 
 /* Adds an object
  * Requires: web request, key name, db connection
- * Returns: callback(error, object):
+ * Calls: callback(error, object):
  *  error - null if the object was added or an error otherwise
  *  object - if error is null, the object that was added
  */
 exports.add = function(req, keyName, defaultValues, db, callback) {
+  callback = callback || utils.placeholder;
   db.incr(keyName, function(err, id) {
     if (err) {
-      return callback(err);
+      callback(err);
     }
+    else {
+      var identifier = id;
+      var objectItem = defaultValues;
 
-    var identifier = id;
+      objectItem.id = identifier;
+      objectItem.identifier = utils.generateUniqueId(req.body.title, identifier),
+      keyName = keyName + ':' + identifier;
 
-    var objectItem = defaultValues;
-    objectItem.id = identifier;
-    objectItem.identifier = utils.generateUniqueId(req.body.title, identifier),
-
-    keyName = keyName + ':' + identifier;
-
-    db.set(keyName, JSON.stringify(objectItem), function(errAddObject, response) {
-      if (errAddObject) {
-        return callback(errAddObject);
-      }
-
-      db.get(keyName, function(errObject, objectItem) {
-        if (errObject || !objectItem) {
-          return callback(errObject);
+      db.set(keyName, JSON.stringify(objectItem), function(errAddObject, response) {
+        if (errAddObject) {
+          callback(errAddObject);
         }
-
-        return callback(null, JSON.parse(objectItem));
+        else {
+          db.get(keyName, function(errObject, objectItem) {
+            if (errObject || !objectItem) {
+              callback(errObject);
+            }
+            else {
+              callback(null, JSON.parse(objectItem));
+            }
+          });
+        }
       });
-    });
+    }
   });
 };
 
 /* Updates an object
  * Requires: web request, key name, allowed fields, db connection
- * Returns: callback(error, object):
+ * Calls: callback(error, object):
  *  error - null if object was updated or error otherwise
  *  object - if error is null, the object that was updated
  */
 exports.update = function(req, keyName, allowedFields, db, callback) {
+  callback = callback || utils.placeholder;
   db.get(keyName, function(err, objectItem) {
     if (err || !objectItem) {
-      return callback(err);
+      callback(err);
     }
-
-    var updatedObject = utils.updateObject(req, objectItem, allowedFields);
-    
-    db.set(keyName, updatedObject, function(errSet) {
-      if (errSet) {
-        return callback(errSet);
-      }
-
-      return callback(null, updatedObject);
-    });
+    else {
+      var updatedObject = utils.updateObject(req, objectItem, allowedFields);
+      db.set(keyName, JSON.stringify(updatedObject), function(errSet) {
+        if (errSet) {
+          callback(errSet);
+        }
+        else {
+          callback(null, updatedObject);
+        }
+      });
+    }
   });
 };
 
 /* Removes an object
  * Requires: key name, db connection
- * Returns: callback(error):
+ * Calls: callback(error):
  *  error - null if the object was removed or an error otherwise
  */
 exports.remove = function(keyName, db, callback) {
+  callback = callback || utils.placeholder;
   db.del(keyName, function(err) {
-    return callback(err);
+    callback(err);
   });
 };

--- a/lib/crud.js
+++ b/lib/crud.js
@@ -3,10 +3,12 @@
 var utils = require('./utils');
 
 /* Returns a list of the requested object
- * Requires: web request, key name, allowed fields, db connection
- * Returns: Object list if successful, error otherwise
+ * Requires: key name, allowed fields, db connection, callback
+ * Returns: callback(error, objectList):
+ *  error - null if object list was retrieved or an error otherwise
+ *  objectList - if error is null, the list of objects
  */
-exports.list = function(req, keyName, allowedFields, db, callback) {
+exports.list = function(keyName, allowedFields, db, callback) {
   var objectList = [];
 
   db.keys(keyName, function(err, objects) {
@@ -17,10 +19,7 @@ exports.list = function(req, keyName, allowedFields, db, callback) {
     objects.forEach(function(objectItem, counter) {
       db.get(objectItem, function(errObject, objectItem) {
         objectItem = JSON.parse(objectItem);
-
-        var objectHash = utils.updateObject(req, objectItem, allowedFields);
-
-        objectList.unshift(objectHash);
+        objectList.unshift(objectItem);
 
         if (counter === objects.length - 1) {
           return callback(null, objectList);
@@ -31,10 +30,12 @@ exports.list = function(req, keyName, allowedFields, db, callback) {
 };
 
 /* Gets an object
- * Requires: web request, key name, db connection
- * Returns: Object if successful, error otherwise
+ * Requires: key name, db connection
+ * Returns: callback(error, object):
+ *  error - null if object was retrieved or an error otherwise
+ *  object - if error is null, the object
  */
-exports.get = function(req, keyName, db, callback) {
+exports.get = function(keyName, db, callback) {
   db.get(keyName, function(err, objectItem) {
     if (err || !objectItem) {
       return callback(err);
@@ -46,7 +47,9 @@ exports.get = function(req, keyName, db, callback) {
 
 /* Adds an object
  * Requires: web request, key name, db connection
- * Returns: Object if successful, error otherwise
+ * Returns: callback(error, object):
+ *  error - null if the object was added or an error otherwise
+ *  object - if error is null, the object that was added
  */
 exports.add = function(req, keyName, defaultValues, db, callback) {
   db.incr(keyName, function(err, id) {
@@ -80,7 +83,9 @@ exports.add = function(req, keyName, defaultValues, db, callback) {
 
 /* Updates an object
  * Requires: web request, key name, allowed fields, db connection
- * Returns: True if successful, error otherwise
+ * Returns: callback(error, object):
+ *  error - null if object was updated or error otherwise
+ *  object - if error is null, the object that was updated
  */
 exports.update = function(req, keyName, allowedFields, db, callback) {
   db.get(keyName, function(err, objectItem) {
@@ -100,16 +105,13 @@ exports.update = function(req, keyName, allowedFields, db, callback) {
   });
 };
 
-/* Deletes an object
- * Requires: web request, key name, db connection
- * Returns: True if successful, error otherwise
+/* Removes an object
+ * Requires: key name, db connection
+ * Returns: callback(error):
+ *  error - null if the object was removed or an error otherwise
  */
-exports.remove = function(req, keyName, db, callback) {
+exports.remove = function(keyName, db, callback) {
   db.del(keyName, function(err) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, true);
+    return callback(err);
   });
 };

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -6,76 +6,30 @@ const ALLOWED_FIELDS = {
         src: undefined
       };
 
-var crud = require('./crud');
+var scaffold = require('./scaffold');
 
-/* Element List Per Component
- * Requires: web request, db connection
- * Returns: A listing of the user's elements within a component
+/* Get Element Prefix
+ * Requires: web request
+ * Returns: database prefix for elements
  */
-exports.list = function(req, db, callback) {
-  crud.list(req, 'project:' + req.body.project_id + ':component:' + req.params.id + ':element:*',
-    ALLOWED_FIELDS, db, function(err, elementList) {
-    
-    if (err) {
-      return callback(err);
-    }
+function getElementPrefix(req) {
+  return 'project:' + req.body.project_id + ':component:' + req.params.id
+    + ':element';
+}
 
-    return callback(null, elementList);
-  });
-};
-
-/* Element Add
- * Requires: web request, db connection
- * Returns: Element object if successful, false if email doesn't match, error if unsuccessful
+/* Get Default Element
+ * Requires: web request
+ * Returns: default element data
  */
-exports.add = function(req, db, callback) {
-  var defaultValues = {
+function getDefaultElement(req) {
+  return {
     type: req.body.type,
     title: req.body.title,
     layout: req.body.layout,
     required: req.body.required || false,
     src: req.body.src
   };
+}
 
-  crud.add(req, 'project:' + req.body.project_id + ':component:' + req.params.id + ':element',
-    defaultValues, db, function(err, element) {
-    
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, element);
-  });
-};
-
-/* Element Update
- * Requires: web request, db connection, identifier
- * Returns: Element object if successful, false if email doesn't match, error if unsuccessful
- */
-exports.update = function(req, db, identifier, callback) {
-  crud.update(req, 'project:' + req.body.project_id + ':component:' + req.params.id + ':element:' + identifier,
-    ALLOWED_FIELDS, db, function(err, element) {
-    
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, element);
-  });
-};
-
-/* Element Delete
- * Requires: web request, db connection
- * Returns: True if deleted, false if email doesn't match, error if unsuccessful
- */
-exports.remove = function(req, db, identifier, callback) {
-  crud.remove(req, 'project:' + req.body.project_id + ':componenet:' + req.params.id + ':element:' + identifier,
-    db, function(err, status) {
-    
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, status);
-  });
-};
+exports = module.exports = scaffold.generate(getElementPrefix,
+    getDefaultElement, ALLOWED_FIELDS);

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -13,8 +13,8 @@ var scaffold = require('./scaffold');
  * Returns: database prefix for elements
  */
 function getElementPrefix(req) {
-  return 'project:' + req.body.project_id + ':component:' + req.params.id
-    + ':element';
+  return 'project:' + req.body.project_id + ':component:' + req.params.id +
+    ':element';
 }
 
 /* Get Default Element

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -3,80 +3,36 @@ const ALLOWED_FIELDS = {
         author: undefined
       };
 
-var crud = require('./crud');
+var scaffold = require('./scaffold');
 
-/* Project List
- * Requires: web request, db connection
- * Returns: A listing of the user's projects
+/* Get Project Prefix
+ * Requires: web request
+ * Returns: database prefix for project
  */
-exports.list = function(req, db, callback) {
-  crud.list(req, 'project:' + req.session.email + ':*', ALLOWED_FIELDS, db, function(err, projectList) {
-    if (err) {
-      return callback(err);
-    }
+function getProjectPrefix(req) {
+  return 'project:' + req.session.email;
+}
 
-    return callback(null, projectList);
-  });
-};
-
-/* Project Get
- * Requires: web request, db connection, identifier
- * Returns: A project object if found, error if not found
+/* Get Default Project
+ * Requires: web request
+ * Returns: default project data
  */
-exports.get = function(req, db, identifier, callback) {
-  crud.get(req, 'project:' + req.session.email + ':' + identifier, db, function(err, project) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, project);
-  });
-};
-
-/* Project Add
- * Requires: web request, db connection
- * Returns: Project object if successful, error if unsuccessful
- */
-exports.add = function(req, db, callback) {
-  var defaultValues = {
+function getDefaultProject(req) {
+  return {
     title: req.body.title,
     author: req.session.email,
     created: new Date().getTime()
   };
+}
 
-  crud.add(req, 'project:' + req.session.email, defaultValues, db, function(err, project) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, project);
-  });
-};
-
-/* Project Update
- * Requires: web request, db connection, identifier
- * Returns: Project object if successful, false if email doesn't match, error if unsuccessful
+/* 
+ * Directly assigning `exports` alone won't do anything, as node only exports
+ * the properties of `exports` and not a reassigned object. Assigning
+ * `module.exports`, however, will force node to export the reassigned object.
+ * It is still necessary to assign `exports` back to `module.exports` so that
+ * it is referencing the newly updated exports object; in this way, the user
+ * can continue to use `exports.someProperty = someValue;` and have
+ * someProperty exported by node.
  */
-exports.update = function(req, db, identifier, callback) {
-  crud.update(req, 'project:' + req.session.email + ':' + identifier, ALLOWED_FIELDS, db, function(err, project) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, project);
-  });
-};
-
-/* Project Delete
- * Requires: web request, db connection
- * Returns: True if deleted, error if unsuccessful
- */
-exports.remove = function(req, db, identifier, callback) {
-  crud.remove(req, 'project:' + req.session.email + ':' + identifier, db, function(err, status) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, status);
-  });
-};
+exports = module.exports = scaffold.generate(getProjectPrefix,
+    getDefaultProject, ALLOWED_FIELDS);

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -1,0 +1,106 @@
+var crud = require('./crud');
+
+/* Generate a CRUD scaffold for an object
+ *
+ * Requires:
+ *  getPrefix - function(req) which returns a prefix based on a request
+ *  getDefault - function(req) which returns a default object based on
+ *    a request
+ *  allowedFields - fields that are allowed to be modified in the form of
+ *    a map
+ *
+ * Returns: the scaffold in the form of an object with the following methods:
+ *  list(req, db, callback) - get a list of the scaffolded objects
+ *  get(req, db, identifier, callback) - get a specific object
+ *  add(req, db, callback) - add an object
+ *  update(req, db, identifier, callback) - update an object
+ *  remove(req, db, identifier, callback) - remove an object
+ */
+exports.generate = function(getPrefix, getDefault, allowedFields) {
+  var scaffold = {};
+
+  /* Object List
+   * Requires: web request, db connection, callback
+   * Returns: callback(error, objectList):
+   *  error - null if object list was retrieved or an error otherwise
+   *  objectList - if error is null, the list of objects
+   */
+  scaffold.list = function(req, db, callback) {
+    var key = getPrefix(req) + ':*';
+    crud.list(key, allowedFields, db, function(err, objectList) {
+      if (err) {
+        return callback(err);
+      }
+
+      return callback(null, objectList);
+    });
+  };
+
+  /* Object Get
+   * Requires: web request, db connection, identifier, callback
+   * Returns: callback(error, object):
+   *  error - null if object was retrieved or an error otherwise
+   *  object - if error is null, the object
+   */
+  scaffold.get = function(req, db, identifier, callback) {
+    var key = getPrefix(req) + ':' + identifier;
+    crud.get(key, db, function(err, object) {
+      if (err) {
+        return callback(err);
+      }
+
+      return callback(null, object);
+    });
+  };
+
+  /* Object Add
+   * Requires: web request, db connection, callback
+   * Returns: callback(error, object):
+   *  error - null if the object was added or an error otherwise
+   *  object - if error is null, the object that was added
+   */
+  scaffold.add = function(req, db, callback) {
+    var defaultValues = getDefault(req);
+    var key = getPrefix(req);
+
+    crud.add(req, key, defaultValues, db, function(err, object) {
+      if (err) {
+        return callback(err);
+      }
+
+      return callback(null, object);
+    });
+  };
+
+  /* Object Update
+   * Requires: web request, db connection, identifier, callback
+   * Returns: callback(error, object):
+   *  error - null if object was updated or error otherwise
+   *  object - if error is null, the object that was updated
+   */
+  scaffold.update = function(req, db, identifier, callback) {
+    var key = getPrefix(req) + ':' + identifier;
+    crud.update(req, key, allowedFields, db, function(err, project) {
+      if (err) {
+        return callback(err);
+      }
+
+      return callback(null, project);
+    });
+  };
+
+  /* Object Remove
+   * Requires: web request, db connection, callback
+   * Returns: callback(error):
+   *  error - null if the object was removed or an error otherwise
+   */
+  scaffold.remove = function(req, db, identifier, callback) {
+    var key = getPrefix(req) + ':' + identifier;
+    crud.remove(key, db, function(err, status) {
+      return callback(err);
+    });
+  };
+
+  return scaffold;
+}
+

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -1,4 +1,5 @@
 var crud = require('./crud');
+var utils = require('./utils');
 
 /* Generate a CRUD scaffold for an object
  *
@@ -21,7 +22,7 @@ exports.generate = function(getPrefix, getDefault, allowedFields) {
 
   /* Object List
    * Requires: web request, db connection, callback
-   * Returns: callback(error, objectList):
+   * Calls: callback(error, objectList):
    *  error - null if object list was retrieved or an error otherwise
    *  objectList - if error is null, the list of objects
    */
@@ -29,16 +30,17 @@ exports.generate = function(getPrefix, getDefault, allowedFields) {
     var key = getPrefix(req) + ':*';
     crud.list(key, allowedFields, db, function(err, objectList) {
       if (err) {
-        return callback(err);
+        callback(err);
       }
-
-      return callback(null, objectList);
+      else {
+        callback(null, objectList);
+      }
     });
   };
 
   /* Object Get
    * Requires: web request, db connection, identifier, callback
-   * Returns: callback(error, object):
+   * Calls: callback(error, object):
    *  error - null if object was retrieved or an error otherwise
    *  object - if error is null, the object
    */
@@ -46,16 +48,17 @@ exports.generate = function(getPrefix, getDefault, allowedFields) {
     var key = getPrefix(req) + ':' + identifier;
     crud.get(key, db, function(err, object) {
       if (err) {
-        return callback(err);
+        callback(err);
       }
-
-      return callback(null, object);
+      else {
+        callback(null, object);
+      }
     });
   };
 
   /* Object Add
    * Requires: web request, db connection, callback
-   * Returns: callback(error, object):
+   * Calls: callback(error, object):
    *  error - null if the object was added or an error otherwise
    *  object - if error is null, the object that was added
    */
@@ -63,44 +66,50 @@ exports.generate = function(getPrefix, getDefault, allowedFields) {
     var defaultValues = getDefault(req);
     var key = getPrefix(req);
 
+    callback = callback || utils.placeholder;
     crud.add(req, key, defaultValues, db, function(err, object) {
       if (err) {
-        return callback(err);
+        callback(err);
       }
-
-      return callback(null, object);
+      else {
+        callback(null, object);
+      }
     });
   };
 
   /* Object Update
    * Requires: web request, db connection, identifier, callback
-   * Returns: callback(error, object):
+   * Calls: callback(error, object):
    *  error - null if object was updated or error otherwise
    *  object - if error is null, the object that was updated
    */
   scaffold.update = function(req, db, identifier, callback) {
     var key = getPrefix(req) + ':' + identifier;
+    callback = callback || utils.placeholder;
+
     crud.update(req, key, allowedFields, db, function(err, project) {
       if (err) {
-        return callback(err);
+        callback(err);
       }
-
-      return callback(null, project);
+      else {
+        callback(null, project);
+      }
     });
   };
 
   /* Object Remove
    * Requires: web request, db connection, callback
-   * Returns: callback(error):
+   * Calls: callback(error):
    *  error - null if the object was removed or an error otherwise
    */
   scaffold.remove = function(req, db, identifier, callback) {
     var key = getPrefix(req) + ':' + identifier;
+    callback = callback || utils.placeholder;
+
     crud.remove(key, db, function(err, status) {
-      return callback(err);
+      callback(err);
     });
   };
 
   return scaffold;
-}
-
+};

--- a/lib/screens.js
+++ b/lib/screens.js
@@ -4,80 +4,27 @@ const ALLOWED_FIELDS = {
         layout: undefined
       };
 
-var crud = require('./crud');
+var scaffold = require('./scaffold');
 
-/* Screen List Per Project
- * Requires: web request, db connection
- * Returns: A listing of the user's screens within a project
+/* Get Screen Prefix
+ * Requires: web request
+ * Returns: database prefix for screen
  */
-exports.list = function(req, db, callback) {
-  crud.list(req, 'project:' + req.params.id + ':screen:*', ALLOWED_FIELDS, db, function(err, screenList) {
-    if (err) {
-      return callback(err);
-    }
+function getScreenPrefix(req) {
+  return 'project:' + req.session.email + ':screen';
+}
 
-    return callback(null, screenList);
-  });
-};
-
-/* Screen Get
- * Requires: web request, db connection, identifier
- * Returns: A screen object if found, error if not found
+/* Get Default Screen
+ * Requires: web request
+ * Returns: default screen data
  */
-exports.get = function(req, db, identifier, callback) {
-  crud.get(req, 'project:' + req.params.id + ':screen:' + identifier, db, function(err, screen) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, screen);
-  });
-};
-
-/* Screen Add
- * Requires: web request, db connection
- * Returns: Screen object if successful, false if email doesn't match, error if unsuccessful
- */
-exports.add = function(req, db, callback) {
-  var defaultValues = {
+function getDefaultScreen(req) {
+  return {
     title: req.body.title,
     is_start: req.body.is_start,
     layout: req.body.layout
   };
+}
 
-  crud.add(req, 'project:' + req.params.id + ':screen', defaultValues, db, function(err, screen) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, screen);
-  });
-};
-
-/* Screen Update
- * Requires: web request, db connection, identifier
- * Returns: Screen object if successful, false if email doesn't match, error if unsuccessful
- */
-exports.update = function(req, db, identifier, callback) {
-  crud.update(req, 'project:' + req.params.id + ':screen:' + identifier, ALLOWED_FIELDS, db, function(err, screen) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, screen);
-  });
-};
-
-/* Screen Delete
- * Requires: web request, db connection
- * Returns: True if deleted, false if email doesn't match, error if unsuccessful
- */
-exports.remove = function(req, db, identifier, callback) {
-  crud.remove(req, 'project:' + req.params.id + ':screen:' + identifier, db, function(err, status) {
-    if (err) {
-      return callback(err);
-    }
-
-    return callback(null, status);
-  });
-};
+exports = module.exports = scaffold.generate(getScreenPrefix,
+    getDefaultScreen, ALLOWED_FIELDS);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -47,3 +47,7 @@ exports.updateObject = function(req, currObject, allowedFields) {
 
   return false;
 };
+
+/* No operation placeholder for empty callbacks */
+exports.placeholder = function() {};
+

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -50,4 +50,3 @@ exports.updateObject = function(req, currObject, allowedFields) {
 
 /* No operation placeholder for empty callbacks */
 exports.placeholder = function() {};
-

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "jade": ">= 0.20.3",
     "request": "2.9.153",
     "socket.io": "0.9.6",
-    "nconf": "git://github.com/flatiron/nconf.git",
+    "nconf": "0.6.0",
     "hiredis": "0.1.14",
     "redis": "0.7.1",
     "winston": "0.6.1"

--- a/test/test.components.js
+++ b/test/test.components.js
@@ -102,8 +102,8 @@ describe('component', function() {
       var req = componentReq;
       
       components.add(req, db, function(errComponent, component) {
-        components.remove(req, db, 1, function(err, status) {
-          status.should.equal(true);
+        components.remove(req, db, 1, function(err) {
+          should.not.exist(err);
           done();
         });
       });

--- a/test/test.components.js
+++ b/test/test.components.js
@@ -54,59 +54,124 @@ var componentReq = {
 };
 
 describe('component', function() {
+  before(function(done) {
+    var req = projectReq;
+    projects.add(req, db, function(err, project) {
+        req = screenReq;
+        screens.add(req, db, done);
+    });
+  });
+
   after(function(done) {
     db.flushdb(done);
     console.log('cleared test components database');
   });
 
+  describe('POST /component', function() {
+    var req = componentReq;
+
+    it('adds a new component', function(done) {
+      components.add(req, db, function(err, component) {
+        component.type.should.equal(req.body.type);
+        component.layout.should.equal(req.body.layout);
+        component.action.should.equal(req.body.action);
+        done();
+      });
+    });
+
+    it('accepts an empty callback', function(done) {
+      components.add(req, db);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        components.get(req, db, 2, function(err, component) {
+          component.type.should.equal(req.body.type);
+          component.layout.should.equal(req.body.layout);
+          component.action.should.equal(req.body.action);
+          done();
+        });
+      }, 10);
+    });
+  });
+
   describe('GET /list', function() {
     it('returns a list of available components for the screen', function(done) {
-      var req = projectReq;
+      var req = componentReq;
 
-      projects.add(req, db, function(err, project) {
-        req = screenReq;
+      components.list(req, db, function(errList, componentList) {
+        componentList[0].type.should.equal(req.body.type);
+        componentList[0].layout.should.equal(req.body.layout);
+        componentList[0].action.should.equal(req.body.action);
+        done();
+      });
+    });
+  });
 
-        screens.add(req, db, function(errScreen, screen) {
-          req = componentReq;
+  describe('GET /component/:id', function() {
+    var req = componentReq;
 
-          components.add(req, db, function(errComponent, component) {
-            components.list(req, db, function(errList, componentList) {
-              componentList[0].type.should.equal(req.body.type);
-              componentList[0].layout.should.equal(req.body.layout);
-              componentList[0].action.should.equal(req.body.action);
-              done();
-            });
-          });
-        });
+    it('returns a specific component', function(done) {
+      components.get(req, db, 1, function(err, component) {
+        component.type.should.equal(req.body.type);
+        component.layout.should.equal(req.body.layout);
+        component.action.should.equal(req.body.action);
+        done();
+      });
+    });
+
+    it('returns no component', function(done) {
+      components.get(req, db, 12345, function(err, component) {
+        should.not.exist(component);
+        done();
       });
     });
   });
 
   describe('PUT /component/:id', function() {
+    var req = componentReq;
+
     it('updates a component', function(done) {
-      var req = componentReq;
+      req.body.layout = 'row2';
+      components.update(req, db, 1, function(err, component) {
+        component.layout.should.equal(req.body.layout);
+        done();
+      });
+    });
 
-      components.add(req, db, function(errComponent, component) {
-        req.body.layout = 'row2';
+    it('accepts an empty callback', function(done) {
+      req.body.layout = 'row3';
+      components.update(req, db, 1);
 
-        components.update(req, db, 1, function(err, component) {
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        components.get(req, db, 1, function(err, component) {
           component.layout.should.equal(req.body.layout);
           done();
         });
-      });
+      }, 10);
     });
   });
 
   describe('DELETE /component/:id', function() {
+    var req = componentReq;
+
     it('attempts to delete a component', function(done) {
-      var req = componentReq;
-      
-      components.add(req, db, function(errComponent, component) {
-        components.remove(req, db, 1, function(err) {
-          should.not.exist(err);
+      components.remove(req, db, 1, function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('accepts an empty callback', function(done) {
+      components.remove(req, db, 2);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        components.list(req, db, function(error, componentList) {
+          componentList.should.eql([]);
           done();
         });
-      });
+      }, 10);
     });
   });
 });

--- a/test/test.elements.js
+++ b/test/test.elements.js
@@ -71,63 +71,138 @@ var elementReq = {
 };
 
 describe('element', function() {
+  before(function(done) {
+    var req = projectReq;
+
+    projects.add(req, db, function(err, project) {
+      req = screenReq;
+      screens.add(req, db, function(errScreen, screen) {
+        req = componentReq;
+        components.add(req, db, function(errComponent, component) {
+          done();
+        });
+      });
+    });
+  });
+
   after(function(done) {
     db.flushdb(done);
     console.log('cleared test elements database');
   });
 
+  describe('POST /element', function() {
+    var req = elementReq;
+
+    it('adds a new element', function(done) {
+      elements.add(req, db, function(err, element) {
+        element.type.should.equal(req.body.type);
+        element.layout.should.equal(req.body.layout);
+        element.required.should.equal(req.body.required);
+        element.src.should.equal(req.body.src);
+        done();
+      });
+    });
+
+    it('accepts an empty callback', function(done) {
+      elements.add(req, db);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        elements.get(req, db, 2, function(err, element) {
+          element.type.should.equal(req.body.type);
+          element.layout.should.equal(req.body.layout);
+          element.required.should.equal(req.body.required);
+          element.src.should.equal(req.body.src);
+          done();
+        });
+      }, 10);
+    });
+  });
+
   describe('GET /list', function() {
     it('returns a list of available elements for the component', function(done) {
-      var req = projectReq;
+      var req = elementReq;
 
-      projects.add(req, db, function(err, project) {
-        req = screenReq;
+      elements.list(req, db, function(errList, elementList) {
+        elementList[0].type.should.equal(req.body.type);
+        elementList[0].layout.should.equal(req.body.layout);
+        elementList[0].required.should.equal(req.body.required);
+        elementList[0].src.should.equal(req.body.src);
+        elementList[1].type.should.equal(req.body.type);
+        elementList[1].layout.should.equal(req.body.layout);
+        elementList[1].required.should.equal(req.body.required);
+        elementList[1].src.should.equal(req.body.src);
+        done();
+      });
+    });
+  });
 
-        screens.add(req, db, function(errScreen, screen) {
-          req = componentReq;
+  describe('GET /element/:id', function() {
+    var req = elementReq;
 
-          components.add(req, db, function(errComponent, component) {
-            req = elementReq;
+    it('returns a specific element', function(done) {
+      elements.get(req, db, 1, function(err, element) {
+        element.type.should.equal(req.body.type);
+        element.layout.should.equal(req.body.layout);
+        element.required.should.equal(req.body.required);
+        element.src.should.equal(req.body.src);
+        done();
+      });
+    });
 
-            elements.add(req, db, function(errElement, element) {
-              elements.list(req, db, function(errList, elementList) {
-                elementList[0].type.should.equal(req.body.type);
-                elementList[0].layout.should.equal(req.body.layout);
-                elementList[0].required.should.equal(req.body.required);
-                done();
-              });
-            });
-          });
-        });
+    it('returns no element', function(done) {
+      elements.get(req, db, 12345, function(err, element) {
+        should.not.exist(element);
+        done();
       });
     });
   });
 
   describe('PUT /element/:id', function() {
+    var req = elementReq;
+
     it('updates a specific element', function(done) {
-      var req = elementReq;
+      req.body.layout = 'row2';
+      elements.update(req, db, 1, function(err, element) {
+        element.layout.should.equal(req.body.layout);
+        done();
+      });
+    });
 
-      elements.add(req, db, function(errElement, element) {
-        req.body.layout = 'row2';
+    it('accepts an empty callback', function(done) {
+      req.body.layout = 'row3';
+      elements.update(req, db, 1);
 
-        elements.update(req, db, 1, function(err, element) {
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        elements.get(req, db, 1, function(err, element) {
           element.layout.should.equal(req.body.layout);
           done();
         });
-      });
+      }, 10);
     });
   });
 
   describe('DELETE /element/:id', function() {
-    it('deletes an element', function(done) {
-      var req = elementReq;
+    var req = elementReq;
 
-      elements.add(req, db, function(errElement, element) {
-        elements.remove(req, db, 1, function(err) {
-          should.not.exist(err);
+    it('deletes an element', function(done) {
+      elements.remove(req, db, 1, function(err) {
+        should.not.exist(err);
+        done();
+      });
+    });
+
+    it('accepts an empty callback', function(done) {
+      elements.remove(req, db, 2);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        elements.list(req, db, function(error, elementList) {
+          elementList.should.eql([]);
           done();
         });
-      });
+      }, 10);
     });
   });
 });

--- a/test/test.elements.js
+++ b/test/test.elements.js
@@ -123,8 +123,8 @@ describe('element', function() {
       var req = elementReq;
 
       elements.add(req, db, function(errElement, element) {
-        elements.remove(req, db, 1, function(err, element) {
-          element.should.equal(true);
+        elements.remove(req, db, 1, function(err) {
+          should.not.exist(err);
           done();
         });
       });

--- a/test/test.projects.js
+++ b/test/test.projects.js
@@ -32,52 +32,109 @@ describe('project', function() {
     console.log('cleared test projects database');
   });
 
+  describe('POST /project', function() {
+    var req = projectReq;
+
+    it('adds a new project', function(done) {
+      projects.add(req, db, function(err, project) {
+        project.title.should.equal(req.body.title);
+        project.author.should.equal(req.session.email);
+        done();
+      });
+    });
+
+    it('accepts an empty callback', function(done) {
+      projects.add(req, db);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        projects.get(req, db, 2, function(err, project) {
+          project.title.should.equal(req.body.title);
+          project.author.should.equal(req.session.email);
+          done();
+        });
+      }, 10);
+    });
+  });
+
   describe('GET /list', function() {
     it('returns a list of available projects for the user', function(done) {
       var req = projectReq;
 
-      projects.add(req, db, function(err, project) {
-        projects.list(req, db, function(errList, projectList) {
-          projectList[0].title.should.equal(req.body.title);
-          projectList[0].author.should.equal(req.session.email);
-          done();
-        });
+      projects.list(req, db, function(errList, projectList) {
+        projectList[0].title.should.equal(req.body.title);
+        projectList[0].author.should.equal(req.session.email);
+        projectList[1].title.should.equal(req.body.title);
+        projectList[1].author.should.equal(req.session.email);
+        done();
       });
     });
   });
 
   describe('GET /project/:id', function() {
-    it('returns a specific project', function(done) {
-      var req = projectReq;
+    var req = projectReq;
 
+    it('returns a specific project', function(done) {
       projects.get(req, db, 1, function(err, foundProject) {
         foundProject.title.should.equal(req.body.title);
         foundProject.author.should.equal(req.session.email);
         done();
       });
     });
-  });
 
-  describe('PUT /project/:id', function() {
-    it('updates a specific project', function(done) {
-      var req = projectReq;
-      req.body.title = 'My Project2';
-
-      projects.update(req, db, 1, function(err, project) {
-        project.title.should.equal('My Project2');
+    it('returns no project', function(done) {
+      projects.get(req, db, 12345, function(err, project) {
+        should.not.exist(project);
         done();
       });
     });
   });
 
-  describe('DELETE /project/:id', function() {
-    it('deletes a project', function(done) {
-      var req = projectReq;
+  describe('PUT /project/:id', function() {
+    var req = projectReq;
 
+    it('updates a specific project', function(done) {
+      req.body.title = 'My Project2';
+      projects.update(req, db, 1, function(err, project) {
+        project.title.should.equal(req.body.title);
+        done();
+      });
+    });
+
+    it('accepts an empty callback', function(done) {
+      req.body.title = 'My Project3';
+      projects.update(req, db, 1);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        projects.get(req, db, 1, function(err, project) {
+          project.title.should.equal(req.body.title);
+          done();
+        });
+      }, 10);
+    });
+  });
+
+  describe('DELETE /project/:id', function() {
+    var req = projectReq;
+
+    it('deletes a project', function(done) {
       projects.remove(req, db, 1, function(err) {
         should.not.exist(err);
         done();
       });
+    });
+
+    it('accepts an empty callback', function(done) {
+      projects.remove(req, db, 2);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        projects.list(req, db, function(err, projectList) {
+          projectList.should.eql([]);
+          done();
+        });
+      }, 10);
     });
   });
 });

--- a/test/test.projects.js
+++ b/test/test.projects.js
@@ -74,8 +74,8 @@ describe('project', function() {
     it('deletes a project', function(done) {
       var req = projectReq;
 
-      projects.remove(req, db, 1, function(err, status) {
-        status.should.equal(true);
+      projects.remove(req, db, 1, function(err) {
+        should.not.exist(err);
         done();
       });
     });

--- a/test/test.screens.js
+++ b/test/test.screens.js
@@ -38,45 +38,69 @@ var screenReq = {
 };
 
 describe('screen', function() {
+  before(function(done) {
+    var req = projectReq;
+    projects.add(req, db, function(err, project) {
+      done();
+    });
+  });
+
   after(function(done) {
     db.flushdb(done);
     console.log('cleared test screens database');
   });
 
+  describe('POST /screen', function() {
+    var req = screenReq;
+
+    it('adds a new screen', function(done) {
+      screens.add(req, db, function(err, screen) {
+        screen.title.should.equal(req.body.title);
+        screen.is_start.should.equal(req.body.is_start);
+        screen.layout.should.equal(req.body.layout);
+        done();
+      });
+    });
+
+    it('accepts an empty callback', function(done) {
+      screens.add(req, db);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        screens.get(req, db, 2, function(err, screen) {
+          screen.title.should.equal(req.body.title);
+          screen.is_start.should.equal(req.body.is_start);
+          screen.layout.should.equal(req.body.layout);
+          done();
+        });
+      }, 10);
+    });
+  });
+
   describe('GET /list', function() {
     it('returns a list of available screens for the project', function(done) {
-      var req = projectReq;
+      var req = screenReq;
 
-      projects.add(req, db, function(err, project) {
-        req = screenReq;
-
-        screens.add(req, db, function(errScreen, screen) {
-          screens.list(req, db, function(errList, screenList) {
-            screenList[0].title.should.equal(req.body.title);
-            screenList[0].is_start.should.equal(req.body.is_start);
-            screenList[0].layout.should.equal(req.body.layout);
-            done();
-          });
-        });
+      screens.list(req, db, function(errList, screenList) {
+        screenList[0].title.should.equal(req.body.title);
+        screenList[0].is_start.should.equal(req.body.is_start);
+        screenList[0].layout.should.equal(req.body.layout);
+        done();
       });
     });
   });
 
   describe('GET /screen/:id', function() {
-    it('returns a specific screen', function(done) {
-      var req = screenReq;
+    var req = screenReq;
 
-      screens.add(req, db, function(errScreen, screen) {
-        screens.get(req, db, 1, function(err, screen) {
-          screen.title.should.equal(req.body.title);
-          done();
-        });
+    it('returns a specific screen', function(done) {
+      screens.get(req, db, 1, function(err, screen) {
+        screen.title.should.equal(req.body.title);
+        done();
       });
     });
 
     it('returns no screen', function(done) {
-      var req = screenReq;
-
       screens.get(req, db, 12345, function(err, screen) {
         should.not.exist(screen);
         done();
@@ -85,25 +109,50 @@ describe('screen', function() {
   });
 
   describe('PUT /screen/:id', function() {
-    it('updates a specific screen', function(done) {
-      var req = screenReq;
-      req.body.title = 'My Screen2';
+    var req = screenReq;
 
+    it('updates a specific screen', function(done) {
+      req.body.title = 'My Screen2';
       screens.update(req, db, 1, function(err, screen) {
         screen.title.should.equal(req.body.title);
         done();
       });
     });
+
+    it('accepts an empty callback', function(done) {
+      req.body.title = 'My Screen3';
+      screens.update(req, db, 1);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        screens.get(req, db, 1, function(err, screen) {
+          screen.title.should.equal(req.body.title);
+          done();
+        });
+      }, 10);
+    });
   });
 
   describe('DELETE /screen/:id', function() {
-    it('attempts to delete a screen', function(done) {
-      var req = screenReq;
+    var req = screenReq;
 
+    it('attempts to delete a screen', function(done) {
       screens.remove(req, db, 1, function(err) {
         should.not.exist(err);
         done();
       });
+    });
+
+    it('accepts an empty callback', function(done) {
+      screens.remove(req, db, 2);
+
+      // wait 10ms for db transaction to complete
+      setTimeout(function() {
+        screens.list(req, db, function(err, screenList) {
+          screenList.should.eql([]);
+          done();
+        });
+      }, 10);
     });
   });
 });

--- a/test/test.screens.js
+++ b/test/test.screens.js
@@ -100,8 +100,8 @@ describe('screen', function() {
     it('attempts to delete a screen', function(done) {
       var req = screenReq;
 
-      screens.remove(req, db, 1, function(err, status) {
-        status.should.equal(true);
+      screens.remove(req, db, 1, function(err) {
+        should.not.exist(err);
         done();
       });
     });


### PR DESCRIPTION
Similar code in `projects.js`, `component.js`, `elements.js`, and `screens.js` has been refactored into one scaffold generator.
