### PR TITLE
Improve redis performance by switching to hashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
 test:
 	@./node_modules/.bin/mocha
 
+test-projects:
+	@./node_modules/.bin/mocha test/test.projects.js
+
+test-screens:
+	@./node_modules/.bin/mocha test/test.screens.js
+
+test-components:
+	@./node_modules/.bin/mocha test/test.components.js
+
+test-elements:
+	@./node_modules/.bin/mocha test/test.elements.js
+
+test-authenticate:
+	@./node_modules/.bin/mocha test/test.authenticate.js
+
 .PHONY: test

--- a/lib/components.js
+++ b/lib/components.js
@@ -5,13 +5,13 @@ const ALLOWED_FIELDS = {
 
 var scaffold = require('./scaffold');
 
-/* Get Component Prefix
+/* Get Components Key
  * Requires: web request
- * Returns: database prefix for components
+ * Returns: database key for components hash
  */
-function getComponentPrefix(req) {
-  return 'project:' + req.body.project_id + ':screen:' + req.params.id +
-    ':component';
+function getComponentsKey(req) {
+  return req.session.email + ':project:' + req.params.project_id + 'screen:' +
+    req.params.screen_id + ':components';
 }
 
 /* Get Default Component
@@ -26,5 +26,5 @@ function getDefaultComponent(req) {
   };
 }
 
-exports = module.exports = scaffold.generate(getComponentPrefix,
+exports = module.exports = scaffold.generate(getComponentsKey,
     getDefaultComponent, ALLOWED_FIELDS);

--- a/lib/crud.js
+++ b/lib/crud.js
@@ -1,7 +1,6 @@
 // All the Create / Read / Update / Delete commands
 
 var utils = require('./utils');
-var _ = require('underscore')._;
 
 /* Object list
  * Requires: key, allowed fields, db connection, callback
@@ -16,7 +15,7 @@ exports.list = function(key, allowedFields, db, callback) {
     } else if (objectList.length === 0) {
       callback(null, objectList);
     } else {
-      objectList = _.map(objectList, function(object) {
+      objectList = objectList.map(function(object) {
         return JSON.parse(object);
       });
 
@@ -115,8 +114,8 @@ exports.remove = function(key, id, db, callback) {
     if (err) {
       callback(err);
     } else if (numRemoved != 1) {
-      callback('Asked to delete one object, but ' + numRemoved +
-        ' objects were actually removed.');
+      callback(new Error('Asked to delete one object, but ' + numRemoved +
+        ' objects were actually removed.'));
     } else {
       callback(null);
     }

--- a/lib/crud.js
+++ b/lib/crud.js
@@ -1,88 +1,72 @@
 // All the Create / Read / Update / Delete commands
 
 var utils = require('./utils');
+var _ = require('underscore')._;
 
 /* Object list
- * Requires: key name, allowed fields, db connection, callback
+ * Requires: key, allowed fields, db connection, callback
  * Calls: callback(error, objectList):
  *  error - null if object list was retrieved or an error otherwise
  *  objectList - if error is null, the list of objects
  */
-exports.list = function(keyName, allowedFields, db, callback) {
-  var objectList = [];
-
-  db.keys(keyName, function(err, objects) {
+exports.list = function(key, allowedFields, db, callback) {
+  db.hvals(key, function(err, objectList) {
     if (err) {
       callback(err);
-    }
-    else if (objects.length === 0) {
+    } else if (objectList.length === 0) {
       callback(null, objectList);
-    }
-    else {
-      objects.forEach(function(objectItem, counter) {
-        db.get(objectItem, function(errObject, objectItem) {
-          objectItem = JSON.parse(objectItem);
-          objectList.unshift(objectItem);
-
-          if (counter === objects.length - 1) {
-            callback(null, objectList);
-          }
-        });
+    } else {
+      objectList = _.map(objectList, function(object) {
+        return JSON.parse(object);
       });
+
+      callback(null, objectList);
     }
   });
 };
 
 /* Gets an object
- * Requires: key name, db connection, callback
+ * Requires: key, id, db connection, callback
  * Calls: callback(error, object):
  *  error - null if object was retrieved or an error otherwise
  *  object - if error is null, the object
  */
-exports.get = function(keyName, db, callback) {
-  db.get(keyName, function(err, objectItem) {
-    if (err || !objectItem) {
+exports.get = function(key, id, db, callback) {
+  // ensure id is a string
+  id = String(id);
+  db.hget(key, id, function(err, object) {
+    if (err) {
       callback(err);
-    }
-    else {
-      callback(null, JSON.parse(objectItem));
+    } else {
+      callback(null, JSON.parse(object));
     }
   });
 };
 
 /* Adds an object
- * Requires: web request, key name, db connection, callback
+ * Requires: web request, key, default values, db connection, callback
  * Calls: callback(error, object):
  *  error - null if the object was added or an error otherwise
  *  object - if error is null, the object that was added
  */
-exports.add = function(req, keyName, defaultValues, db, callback) {
-  callback = callback || utils.placeholder;
-  db.incr(keyName, function(err, id) {
+exports.add = function(req, key, defaultValues, db, callback) {
+  callback = callback || utils.noop;
+  db.hlen(key, function(err, length) {
     if (err) {
       callback(err);
-    }
-    else {
-      var identifier = id;
-      var objectItem = defaultValues;
+    } else {
+      var object = defaultValues;
+      object.id = length + 1;
 
-      objectItem.id = identifier;
-      objectItem.identifier = utils.generateUniqueId(req.body.title, identifier),
-      keyName = keyName + ':' + identifier;
-
-      db.set(keyName, JSON.stringify(objectItem), function(errAddObject, response) {
-        if (errAddObject) {
-          callback(errAddObject);
-        }
-        else {
-          db.get(keyName, function(errObject, objectItem) {
-            if (errObject || !objectItem) {
-              callback(errObject);
-            }
-            else {
-              callback(null, JSON.parse(objectItem));
-            }
-          });
+      var value = JSON.stringify(object);
+      db.hset(key, String(object.id), value, function(err, status) {
+        if (err) {
+          callback(err);
+        } else if (!status) {
+          callback(new Error('Object already exists in database; ' +
+            "It's value was updated instead of added."));
+        } else {
+          callback(null, object);
         }
       });
     }
@@ -90,24 +74,29 @@ exports.add = function(req, keyName, defaultValues, db, callback) {
 };
 
 /* Updates an object
- * Requires: web request, key name, allowed fields, db connection, callback
+ * Requires: web request, key, id, allowed fields, db connection, callback
  * Calls: callback(error, object):
  *  error - null if object was updated or error otherwise
  *  object - if error is null, the object that was updated
  */
-exports.update = function(req, keyName, allowedFields, db, callback) {
-  callback = callback || utils.placeholder;
-  db.get(keyName, function(err, objectItem) {
-    if (err || !objectItem) {
+exports.update = function(req, key, id, allowedFields, db, callback) {
+  callback = callback || utils.noop;
+  id = String(id);
+
+  this.get(key, id, db, function(err, object) {
+    if (err) {
       callback(err);
-    }
-    else {
-      var updatedObject = utils.updateObject(req, objectItem, allowedFields);
-      db.set(keyName, JSON.stringify(updatedObject), function(errSet) {
+    } else if (!object) {
+      callback(new Error('Cannot update object that does not exist.'));
+    } else {
+      var updatedObject = utils.updateObject(req, object, allowedFields);
+      var value = JSON.stringify(updatedObject);
+
+      db.hset(key, id, value, function(errSet, status) {
         if (errSet) {
           callback(errSet);
-        }
-        else {
+        } else {
+          // status can be ignored because the id must exist to get here
           callback(null, updatedObject);
         }
       });
@@ -116,13 +105,20 @@ exports.update = function(req, keyName, allowedFields, db, callback) {
 };
 
 /* Removes an object
- * Requires: key name, db connection, callback
+ * Requires: key, id, db connection, callback
  * Calls: callback(error):
  *  error - null if the object was removed or an error otherwise
  */
-exports.remove = function(keyName, db, callback) {
-  callback = callback || utils.placeholder;
-  db.del(keyName, function(err) {
-    callback(err);
+exports.remove = function(key, id, db, callback) {
+  callback = callback || utils.noop;
+  db.hdel(key, id, function(err, numRemoved) {
+    if (err) {
+      callback(err);
+    } else if (numRemoved != 1) {
+      callback('Asked to delete one object, but ' + numRemoved +
+        ' objects were actually removed.');
+    } else {
+      callback(null);
+    }
   });
 };

--- a/lib/elements.js
+++ b/lib/elements.js
@@ -8,13 +8,13 @@ const ALLOWED_FIELDS = {
 
 var scaffold = require('./scaffold');
 
-/* Get Element Prefix
+/* Get Elements Key
  * Requires: web request
- * Returns: database prefix for elements
+ * Returns: database key for elements hash
  */
-function getElementPrefix(req) {
-  return 'project:' + req.body.project_id + ':component:' + req.params.id +
-    ':element';
+function getElementsKey(req) {
+  return req.session.email + ':project:' + req.params.project_id + ':screen:' +
+    req.params.screen_id + ':component:' + req.params.component_id + ':elements';
 }
 
 /* Get Default Element
@@ -31,5 +31,5 @@ function getDefaultElement(req) {
   };
 }
 
-exports = module.exports = scaffold.generate(getElementPrefix,
+exports = module.exports = scaffold.generate(getElementsKey,
     getDefaultElement, ALLOWED_FIELDS);

--- a/lib/projects.js
+++ b/lib/projects.js
@@ -5,12 +5,12 @@ const ALLOWED_FIELDS = {
 
 var scaffold = require('./scaffold');
 
-/* Get Project Prefix
+/* Get Projects Key
  * Requires: web request
- * Returns: database prefix for project
+ * Returns: database key for project hash
  */
-function getProjectPrefix(req) {
-  return 'project:' + req.session.email;
+function getProjectsKey(req) {
+  return req.session.email + ':projects';
 }
 
 /* Get Default Project
@@ -34,5 +34,5 @@ function getDefaultProject(req) {
  * can continue to use `exports.someProperty = someValue;` and have
  * someProperty exported by node.
  */
-exports = module.exports = scaffold.generate(getProjectPrefix,
+exports = module.exports = scaffold.generate(getProjectsKey,
     getDefaultProject, ALLOWED_FIELDS);

--- a/lib/scaffold.js
+++ b/lib/scaffold.js
@@ -4,7 +4,8 @@ var utils = require('./utils');
 /* Generate a CRUD scaffold for an object
  *
  * Requires:
- *  getPrefix - function(req) which returns a prefix based on a request
+ *  getKey - function(req) which returns a key to the object's hash based on
+ *    a request
  *  getDefault - function(req) which returns a default object based on
  *    a request
  *  allowedFields - fields that are allowed to be modified in the form of
@@ -17,7 +18,7 @@ var utils = require('./utils');
  *  update(req, db, identifier, callback) - update an object
  *  remove(req, db, identifier, callback) - remove an object
  */
-exports.generate = function(getPrefix, getDefault, allowedFields) {
+exports.generate = function(getKey, getDefault, allowedFields) {
   var scaffold = {};
 
   /* Object List
@@ -27,30 +28,28 @@ exports.generate = function(getPrefix, getDefault, allowedFields) {
    *  objectList - if error is null, the list of objects
    */
   scaffold.list = function(req, db, callback) {
-    var key = getPrefix(req) + ':*';
+    var key = getKey(req);
     crud.list(key, allowedFields, db, function(err, objectList) {
       if (err) {
         callback(err);
-      }
-      else {
+      } else {
         callback(null, objectList);
       }
     });
   };
 
   /* Object Get
-   * Requires: web request, db connection, identifier, callback
+   * Requires: web request, db connection, id, callback
    * Calls: callback(error, object):
    *  error - null if object was retrieved or an error otherwise
    *  object - if error is null, the object
    */
-  scaffold.get = function(req, db, identifier, callback) {
-    var key = getPrefix(req) + ':' + identifier;
-    crud.get(key, db, function(err, object) {
+  scaffold.get = function(req, db, id, callback) {
+    var key = getKey(req);
+    crud.get(key, id, db, function(err, object) {
       if (err) {
         callback(err);
-      }
-      else {
+      } else {
         callback(null, object);
       }
     });
@@ -64,49 +63,48 @@ exports.generate = function(getPrefix, getDefault, allowedFields) {
    */
   scaffold.add = function(req, db, callback) {
     var defaultValues = getDefault(req);
-    var key = getPrefix(req);
+    var key = getKey(req);
 
-    callback = callback || utils.placeholder;
+    callback = callback || utils.noop;
     crud.add(req, key, defaultValues, db, function(err, object) {
       if (err) {
         callback(err);
-      }
-      else {
+      } else {
         callback(null, object);
       }
     });
   };
 
   /* Object Update
-   * Requires: web request, db connection, identifier, callback
+   * Requires: web request, db connection, id, callback
    * Calls: callback(error, object):
    *  error - null if object was updated or error otherwise
    *  object - if error is null, the object that was updated
    */
-  scaffold.update = function(req, db, identifier, callback) {
-    var key = getPrefix(req) + ':' + identifier;
-    callback = callback || utils.placeholder;
+  scaffold.update = function(req, db, id, callback) {
+    var key = getKey(req);
+    callback = callback || utils.noop;
 
-    crud.update(req, key, allowedFields, db, function(err, project) {
-      if (err) {
-        callback(err);
-      }
-      else {
-        callback(null, project);
-      }
-    });
+    crud.update(req, key, id, allowedFields, db,
+      function(err, project) {
+        if (err) {
+          callback(err);
+        } else {
+          callback(null, project);
+        }
+      });
   };
 
   /* Object Remove
-   * Requires: web request, db connection, callback
+   * Requires: web request, db connection, id, callback
    * Calls: callback(error):
    *  error - null if the object was removed or an error otherwise
    */
-  scaffold.remove = function(req, db, identifier, callback) {
-    var key = getPrefix(req) + ':' + identifier;
-    callback = callback || utils.placeholder;
+  scaffold.remove = function(req, db, id, callback) {
+    var key = getKey(req);
+    callback = callback || utils.noop;
 
-    crud.remove(key, db, function(err, status) {
+    crud.remove(key, id, db, function(err, status) {
       callback(err);
     });
   };

--- a/lib/screens.js
+++ b/lib/screens.js
@@ -6,12 +6,12 @@ const ALLOWED_FIELDS = {
 
 var scaffold = require('./scaffold');
 
-/* Get Screen Prefix
+/* Get Screens Key
  * Requires: web request
- * Returns: database prefix for screen
+ * Returns: database key for screen hash
  */
-function getScreenPrefix(req) {
-  return 'project:' + req.session.email + ':screen';
+function getScreensKey(req) {
+  return req.session.email + ':project:' + req.params.project_id + ':screens';
 }
 
 /* Get Default Screen
@@ -26,5 +26,5 @@ function getDefaultScreen(req) {
   };
 }
 
-exports = module.exports = scaffold.generate(getScreenPrefix,
+exports = module.exports = scaffold.generate(getScreensKey,
     getDefaultScreen, ALLOWED_FIELDS);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,4 +49,4 @@ exports.updateObject = function(req, currObject, allowedFields) {
 };
 
 /* No operation placeholder for empty callbacks */
-exports.placeholder = function() {};
+exports.noop = function() {};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "nconf": "0.6.0",
     "hiredis": "0.1.14",
     "redis": "0.7.1",
-    "underscore": "1.3.3",
     "winston": "0.6.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "nconf": "0.6.0",
     "hiredis": "0.1.14",
     "redis": "0.7.1",
+    "underscore": "1.3.3",
     "winston": "0.6.1"
   },
   "devDependencies": {

--- a/test/test.components.js
+++ b/test/test.components.js
@@ -34,7 +34,7 @@ var screenReq = {
     layout: 'col1'
   },
   params: {
-    id: 1
+    project_id: 1
   }
 };
 
@@ -45,11 +45,11 @@ var componentReq = {
   body: {
     type: 'form',
     layout: 'row1',
-    action: '/',
-    project_id: 1
+    action: '/'
   },
   params: {
-    id: 1
+    project_id: 1,
+    screen_id: 1
   }
 };
 

--- a/test/test.elements.js
+++ b/test/test.elements.js
@@ -35,7 +35,7 @@ var screenReq = {
     layout: 'col1'
   },
   params: {
-    id: 1
+    project_id: 1
   }
 };
 
@@ -46,11 +46,11 @@ var componentReq = {
   body: {
     type: 'form',
     layout: 'row1',
-    action: '/',
-    project_id: 1
+    action: '/'
   },
   params: {
-    id: 1
+    project_id: 1,
+    screen_id: 1
   }
 };
 
@@ -62,11 +62,12 @@ var elementReq = {
     type: 'input_text',
     layout: 'row1',
     required: true,
-    src: '',
-    project_id: 1
+    src: ''
   },
   params: {
-    id: 1
+    project_id: 1,
+    screen_id: 1,
+    component_id: 1
   }
 };
 
@@ -78,9 +79,7 @@ describe('element', function() {
       req = screenReq;
       screens.add(req, db, function(errScreen, screen) {
         req = componentReq;
-        components.add(req, db, function(errComponent, component) {
-          done();
-        });
+        components.add(req, db, done);
       });
     });
   });

--- a/test/test.projects.js
+++ b/test/test.projects.js
@@ -20,9 +20,6 @@ var projectReq = {
   },
   body: {
     title: 'My Project'
-  },
-  params: {
-    id: undefined
   }
 };
 

--- a/test/test.screens.js
+++ b/test/test.screens.js
@@ -33,16 +33,14 @@ var screenReq = {
     layout: 'col1'
   },
   params: {
-    id: 1
+    project_id: 1
   }
 };
 
 describe('screen', function() {
   before(function(done) {
     var req = projectReq;
-    projects.add(req, db, function(err, project) {
-      done();
-    });
+    projects.add(req, db, done);
   });
 
   after(function(done) {


### PR DESCRIPTION
We currently use the redis keys function with the wildcard (*) selector to access a list of projects, screens, etc. Yet the documentation for redis directly says that "Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases ... Don't use KEYS in your regular application code" (see http://redis.io/commands/keys).

As a result, I suggest we switch to using redis hashes. Having each key in a hash represent the id of a project, screen, etc. and the value represent the data associated that id will be a simple way to map over our models while maintaining much higher efficiency.

I've been working on this and will attach a commit as soon as issue #6 is resolved, as my code is dependent on those changes.
