### PR TITLE
updating a secondary screen pushes it to the front of the screen list in the project page

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -146,11 +146,6 @@ function NapkinClient(window, document, $, data, undefined) {
       this.activeProjectId = null;
       this.url = null;
       this.reset();
-    },
-
-    // sort screens by title
-    comparator: function(screen) {
-      return screen.get('title');
     }
   });
 


### PR DESCRIPTION
so if i create a screen 'home', then a screen 'dashboard' the order displays like so on the project page:

home, dashboard

but if i edit in dashboard and go back to my project page, it switches:

dashboard, home
