### PR TITLE
In form editing view, return button should not go all the way back to project screen

### DIFF
--- a/public/javascripts/prototype.js
+++ b/public/javascripts/prototype.js
@@ -391,7 +391,7 @@ function NapkinClient(window, document, $, data, undefined) {
       // active component may not be defined if nothing is in focus
       if (this.$activeComponent) {
         this.$activeComponent.removeClass('active');
-        this.trigger('blurComponent');
+        this.trigger('resetActiveComponent');
       }
 
       this.$activeComponent = null;
@@ -772,10 +772,11 @@ function NapkinClient(window, document, $, data, undefined) {
       componentGroup.fetch(); // fetch all components for the layout
 
       this.layoutView.bind('setActiveComponent', this.setActiveComponent, this);
-      this.layoutView.bind('blurComponent', this.blurComponent, this);
+      this.layoutView.bind('resetActiveComponent', this.resetActiveComponent, this);
     },
 
     setActiveComponent: function($component) {
+      var that = this;
       var type = $component.data('type');
       this.componentListView.$el.hide();
 
@@ -789,13 +790,28 @@ function NapkinClient(window, document, $, data, undefined) {
       $('#sidebar').append(this.elementListView.render().$el);
       this.elementListView.centerButtons();
       this.elementListView.populateSelectText();
+
+      var $backButton = this.$('#back');
+      if ($backButton.length > 0) {
+        $backButton.find('span').text('components');
+        $backButton.click(function(event) {
+          event.preventDefault();
+          that.layoutView.resetActiveComponent();
+        });
+      }
     },
 
-    blurComponent: function() {
+    resetActiveComponent: function() {
       this.componentListView.$el.show();
       if (this.elementListView) {
         this.elementListView.unbind('addElement');
         this.elementListView.remove();
+      }
+
+      var $backButton = this.$('#back');
+      if ($backButton.length > 0) {
+        $backButton.find('span').text('project page');
+        $backButton.unbind('click');
       }
     },
 

--- a/views/prototype.jade
+++ b/views/prototype.jade
@@ -8,7 +8,8 @@ block sidebar
       a.btn.btn-danger#back(href='/') &larr; Back to home
     p This is Napkin, a rapid web prototyping tool. You're currently being shared a screen on the right, which is a mockup of one page of a potential website.
   else
-    a.btn.btn-danger#back(href='/##{projectId}') &larr; Back to project page
+    a.btn.btn-danger#back(href='/##{projectId}') &larr; Back to 
+      span project page
 
 block content
   if sharing && !authenticated


### PR DESCRIPTION
When editing a form, this is what I see:

![return button](https://img.skitch.com/20120726-8paxp341tn63jycbb5dh9ius5e.jpg)

The return button takes me back out of this whole screen and back to the front page of this project. Why two steps back, and not just one? If I am working on a screen and want to place a form somewhere, then go back and place an article somewhere, etc. I don't want to exit all the way out of this screen every time.
