### PR TITLE
Placeable form element should not be usable in the sidebar

### DIFF
--- a/public/javascripts/prototype.js
+++ b/public/javascripts/prototype.js
@@ -67,7 +67,9 @@ function NapkinClient(window, document, $, data, undefined) {
     template: _.template($('#component-list-template').html()),
 
     dragOptions: {
-      revert: 'invalid'
+      revert: 'invalid',
+      // don't cancel if input is dragged
+      cancel: ''
     },
 
     render: function() {

--- a/views/templates/lists/component.jade
+++ b/views/templates/lists/component.jade
@@ -6,7 +6,7 @@ script#component-list-template(type='text/template')
 
   .drag-element.form.last-component(data-type='form')
     h3 Form
-    input(type='text', name='text-box')
+    input(type='text', name='text-box', disabled='disabled')
 
   h2 Screen Configuration
   form.screen-config

--- a/views/templates/lists/form-element.jade
+++ b/views/templates/lists/form-element.jade
@@ -4,22 +4,26 @@ script#form-element-list-template(type='text/template')
     li
       .element(data-type='input-text', data-name='input-text')
         label(for='input-text') Text Input: 
-        input(type='text', name='input-text', tabindex='-1')
+        input(type='text', name='input-text', tabindex='-1',
+          disabled='disabled')
       a.btn.btn-success(href='#add-element') +
     li
       .element(data-type='input-radio', data-name='input-radio')
         label(for='input-radio') Radio Input: 
-        input.radio(type='radio', name='input-radio', tabindex='-1')
+        input.radio(type='radio', name='input-radio', tabindex='-1',
+          disabled='disabled')
       a.btn.btn-success(href='#add-element') +
     li
       .element(data-type='input-checkbox', data-name='input-checkbox')
         label(for='input-checkbox') Checkbox Input: 
-        input.checkbox(type='checkbox', name='input-checkbox', tabindex='-1')
+        input.checkbox(type='checkbox', name='input-checkbox',
+          tabindex='-1', disabled='disabled')
       a.btn.btn-success(href='#add-element') +
     li
       .element(data-type='textarea', data-name='textarea')
         label(for='textarea') Textarea: 
-        textarea(rows='8', cols='20', name='textarea', tabindex='-1')
+        textarea(rows='8', cols='20', name='textarea', tabindex='-1',
+          disabled='disabled')
       a.btn.btn-success(href='#add-element') +
 
   if !sharing


### PR DESCRIPTION
The radio button / text field etc. in the form view have a + next to them to add them to the screen, but they're also live. It looks like putting text into them etc. would actually do something but it doesn't.

I suggest either disabling them somehow (preventdefault on click, or so) or making the entire thing the click target for adding them to the form, not just the +.
