### PR TITLE
I can't tell when the project title is focused.

### DIFF
--- a/public/stylesheets/main.styl
+++ b/public/stylesheets/main.styl
@@ -195,7 +195,8 @@ header a
   width 180px
 
 #add-project-form input[type='text']:focus
-  box-shadow(inset 0 3px 4px #303030\, 0 0 3px #666)
+  border-color rgba(82, 168, 236, 0.4)
+  box-shadow(inset 0 3px 4px #303030\, 0 0 8px rgba(82, 168, 236, .4))
   outline none
 
 #add-project-form .btn


### PR DESCRIPTION
Highlighting/selecting the "Enter a new project title…" text would be one way to show me where my cursor is.
Or making the glow brighter, perhaps.
