### PR TITLE
When dragging a form component, make crosshair consistent

### DIFF
--- a/public/javascripts/controllers/component.js
+++ b/public/javascripts/controllers/component.js
@@ -176,6 +176,10 @@ define(['can', './extended', './element', 'models/element', 'helpers/screen-util
           var $element = $(ui.item);
           var elementControl = $element.data('controls')[0];
           elementControl.updateElementPosition();
+          
+          // activate this element, but first deactivate the rest
+          $componentLocation.click();
+          elementControl.activate();
         }
       },
 

--- a/public/javascripts/controllers/element.js
+++ b/public/javascripts/controllers/element.js
@@ -223,6 +223,8 @@ define(['can', './extended', 'models/element', 'helpers/screen-utils', 'can.supe
 
       '{content} .live-element click': function($element, event) {
         if ($element.is(this.element)) {
+          event.preventDefault();
+
           if (this.element.hasClass('active')) {
             // if already activated, deactivate
             this.deactivate();

--- a/public/stylesheets/main.styl
+++ b/public/stylesheets/main.styl
@@ -350,6 +350,9 @@ header a
   cursor crosshair
   z-index 100
 
+.component input
+  cursor crosshair
+
 .article-container
   border-color #4380d3
 
@@ -380,12 +383,17 @@ header a
   margin-left -10px
   margin-right -10px
 
+.live-element label
+  cursor pointer
+
 .live-element input[type="text"], .live-element textarea,
 .share-element input[type="text"], .share-element textarea
   display block
+  cursor pointer
 
 .share-element input[type="text"], .share-element textarea
   width 270px
+  cursor auto
 
 #share .row
   margin-bottom 20px

--- a/views/templates/elements/input-checkbox.jade
+++ b/views/templates/elements/input-checkbox.jade
@@ -7,4 +7,5 @@ script#input-checkbox-element-template(type='text/ejs')
   else
     .live-element.field
       label(for!='<%= elementId %>') <%= name %>: 
-      input(type='checkbox', name!='<%= elementId %>', id!='<%= elementId %>', tabindex='-1')
+      input(type='checkbox', name!='<%= elementId %>', id!='<%= elementId %>',
+        disabled='disabled')

--- a/views/templates/elements/input-radio.jade
+++ b/views/templates/elements/input-radio.jade
@@ -7,4 +7,5 @@ script#input-radio-element-template(type='text/ejs')
   else
     .live-element.field
       label(for!='<%= elementId %>') <%= name %>: 
-      input(type='radio', name!='<%= elementId %>', id!='<%= elementId %>', tabindex='-1')
+      input(type='radio', name!='<%= elementId %>', id!='<%= elementId %>',
+        disabled='disabled')

--- a/views/templates/elements/input-text.jade
+++ b/views/templates/elements/input-text.jade
@@ -7,4 +7,5 @@ script#input-text-element-template(type='text/ejs')
   else
     .live-element.field
       label(for!='<%= elementId %>') <%= name %>: 
-      input(type='text', name!='<%= elementId %>', id!='<%= elementId %>', tabindex='-1')
+      input(type='text', name!='<%= elementId %>', id!='<%= elementId %>',
+        disabled='disabled')

--- a/views/templates/elements/textarea.jade
+++ b/views/templates/elements/textarea.jade
@@ -8,4 +8,4 @@ script#textarea-element-template(type='text/ejs')
     .live-element.field
       label(for!='<%= elementId %>') <%= name %>: 
       textarea(rows='8', cols='20', name!='<%= elementId %>', id!='<%= elementId %>',
-        tabindex='-1')
+        disabled='disabled')


### PR DESCRIPTION
When dragging a form component, the disabled input text box does not show the crosshair cursor type.
