### PR TITLE
When editing a text element, select text so I can overwrite it

### DIFF
--- a/public/javascripts/controllers/element.js
+++ b/public/javascripts/controllers/element.js
@@ -87,7 +87,8 @@ define(['can', './extended', 'models/element', 'helpers/screen-utils', 'helpers/
           if (this.elementModel.justCreated) {
             $popover.find('input, textarea')
               .eq(0)
-              .focus();
+              .focus()
+              .select();
 
             // only do this once
             this.elementModel.justCreated = false;


### PR DESCRIPTION
Place a new heading or paragraph. Click on it to change the text.

The focus will be on the edit field (good) but the text won't be selected, so I have to select it first to start overwriting it.

If you are worried I might accidentally overwrite _useful_ text, then you could just select it if it contains boilerplate text from the first time it was placed.
