### PR TITLE
Placeholder text in FF is the same color as regular input

### DIFF
--- a/public/stylesheets/main.styl
+++ b/public/stylesheets/main.styl
@@ -164,6 +164,16 @@ header a
   box-shadow(inset 0 3px 4px #303030)
   color #eee
 
+// must keep the following two sets of selectors separate, as browsers will
+// ignore a whole line of selectors if one fails
+#sidebar input[type='text']:-moz-placeholder,
+#sidebar textarea:-moz-placeholder
+  color #888
+
+#sidebar input[type='text']::-webkit-input-placeholder,
+#sidebar textarea::-webkit-input-placeholder
+  color #888
+
 #sidebar .field-select
   border 1px solid #444
 


### PR DESCRIPTION
On the "Enter a new project title..." the placeholder text is the same color as the regular input so it's bad for usability because I think something has already been written and that I can't select it to remove it. 

Identity have the same issue and this patch suggests a solution:

https://github.com/mozilla/browserid/pull/2189/files
